### PR TITLE
RbtreeIterator working with libc++ 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,11 @@ This version of pretty printers is written in **python 3** to be used with gdb l
 **Python 2** version of pretty printers for libc++ can be found here:
 
 https://github.com/koutheir/libcxx-pretty-printers
+
+## installation
+
+To use pretty printers:
+```
+git clone https://github.com/koja/libcxx-pretty-printers ~/.gdb/libcxx-pretty-printers
+cp -b ~/.gdb/libcxx-pretty-printers/src/gdbinit ~/.gdbinit
+```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,24 @@
-libcxx-pretty-printers
-======================
+# libcxx-pretty-printers
 
 GDB Pretty Printers for libc++ of Clang/LLVM
+
+## python version in gdb
+
+Python support in gdb is implemented by linking against **libpython**. To find out python version your gdb is using run this in gdb:
+
+```python
+(gdb) python
+>import sys
+>print(sys.version)
+>end
+```
+
+### python 3
+
+This version of pretty printers is written in **python 3** to be used with gdb linked against **libpython3.x**.
+
+### python 2
+
+**Python 2** version of pretty printers for libc++ can be found here:
+
+https://github.com/koutheir/libcxx-pretty-printers

--- a/src/gdbinit
+++ b/src/gdbinit
@@ -1,6 +1,10 @@
 python
+
 import sys 
-sys.path.insert(0, '<path_to_libcxx-pp_src_dir>') 
+from os import path
+
+sys.path.insert(0, path.expanduser('~') + '/.gdb/libcxx-pretty-printers/src')
 from libcxx.v1.printers import register_libcxx_printers 
 register_libcxx_printers (None) 
+
 end

--- a/src/libcxx/v1/printers.py
+++ b/src/libcxx/v1/printers.py
@@ -505,9 +505,10 @@ class StdSetPrinter:
 
 class RbtreeIterator:
     def __init__(self, rbtree):
-        self.node = rbtree['__begin_node_']
+        self.val_ptr = find_type(rbtree.type, '__node_pointer')
+        self.node_type = find_type(rbtree.type, '__node_base_pointer')
+        self.node = rbtree['__begin_node_'].cast(self.node_type)
         self.size = rbtree['__pair3_']['__first_']
-        self.node_type = self.node.type
         self.count = 0
 
     def __iter__(self):
@@ -537,7 +538,7 @@ class RbtreeIterator:
                 node = parent_node
 
             self.node = node.cast(self.node_type)
-        return result
+        return result.cast( self.val_ptr )
 
 class StdRbtreeIteratorPrinter:
     "Print std::set::iterator"


### PR DESCRIPTION
Hi,
managed to pretty print std::set and std::map by fixing the red black tree iterator. Seems like working (i. e. no rigorous testing was done) with gdb "Debian 7.11.1-2+b1" and libc++ 3.9.

I am definitely neither python nor STL guru. This is the simplest solution I was able to create.

Cheers

Jan